### PR TITLE
Nc return to post management

### DIFF
--- a/TabloidCLI/UserInterfaceManagers/NoteManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/NoteManager.cs
@@ -33,6 +33,7 @@ namespace TabloidCLI.UserInterfaceManagers
             Console.WriteLine("1) List Notes");
             Console.WriteLine("2) Add Note");
             Console.WriteLine("3) Delete note ");
+            Console.WriteLine("0) Go back ");
 
 
 
@@ -95,7 +96,7 @@ namespace TabloidCLI.UserInterfaceManagers
 
         private void DeleteNote()
         {
-            Console.WriteLine("what post you  like to put a remove your note  on!");
+            Console.WriteLine("what post you like to a remove your note  on!");
             List<Post> posts = _postRepository.GetAll();
             foreach (Post post in posts)
             {

--- a/TabloidCLI/UserInterfaceManagers/NoteManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/NoteManager.cs
@@ -69,7 +69,7 @@ namespace TabloidCLI.UserInterfaceManagers
 
         private void AddNotes()
         {
-            Console.WriteLine("what post you  like to put a note on!");
+            Console.WriteLine("what post you like to put a note on!");
             List<Post> posts = _postRepository.GetAll();
             foreach (Post post in posts)
             {


### PR DESCRIPTION
#Changes made (summary):
1. added a Console.WriteLine("0) Go back ");on class NoteManager | working on NoteManager.cs


#What should happen When I run this/ how to test this:
  When you run the code you should click the Post manager option (option 4) and you will head to Post details (option 5). Pick a post you want to head to.  Go to Note Management (option 4). If you want to head back to the post details you would need to go to the Go back option (option 0)

#Branch access
  Branch Name: nc-returnToPostManagment
  git fetch --all  to grab branches
